### PR TITLE
Get `0` working as a motion command

### DIFF
--- a/src/parse.jl
+++ b/src/parse.jl
@@ -40,7 +40,7 @@ Grammar for Vim's language:
 repeat = "(?:[1-9]\\d*)?"
 # motion="[\$%^\\(\\)wWeE{}hjklGHLbB]"
 motion=begin
-    implemented_keys = join(keys(motions))
+    implemented_keys = join([k for k in keys(motions) if k != '0'])
     "[$implemented_keys]"
     # a = "[\$%^\\(\\)]"
     # a = "[
@@ -52,7 +52,7 @@ rules = OrderedDict(
     # insert commands
     r"^(?<c>[aAiIoO])$" => InsertCommand,
     # Special case: `0` is a motion command:
-    "^(?<n1>)(?<motion>0)\$" |> Regex => MotionCommand,
+    "^0\$" |> Regex => (() -> MotionCommand(nothing, '0')),
     # synonym commands
     "^(?<n1>$repeat)(?<c>[xX])\$" |> Regex => SynonymCommand,
     "^(?<n1>$repeat)(?<motion>$motion)\$" |> Regex => MotionCommand,

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -37,7 +37,7 @@ Grammar for Vim's language:
         dd
         3dd
 """
-repeat = "\\d*"
+repeat = "(?:[1-9]\\d*)?"
 # motion="[\$%^\\(\\)wWeE{}hjklGHLbB]"
 motion=begin
     implemented_keys = join(keys(motions))
@@ -51,6 +51,8 @@ operator="[ydc]"
 rules = OrderedDict(
     # insert commands
     r"^(?<c>[aAiIoO])$" => InsertCommand,
+    # Special case: `0` is a motion command:
+    "^(?<n1>)(?<motion>0)\$" |> Regex => MotionCommand,
     # synonym commands
     "^(?<n1>$repeat)(?<c>[xX])\$" |> Regex => SynonymCommand,
     "^(?<n1>$repeat)(?<motion>$motion)\$" |> Regex => MotionCommand,

--- a/test/command.jl
+++ b/test/command.jl
@@ -29,7 +29,7 @@ end
 
 @testset "0: beginning of line" begin
 
-    @test_broken run("an exampl|e sentence", "0") == testbuf("|an example sentence")
+    @test run("an exampl|e sentence", "0") == testbuf("|an example sentence")
 end
 
 


### PR DESCRIPTION
Getting `0` working as a motion command required a couple tweaks:

1. Instead of using `\d*` as a regex for repeats, now use `(?:[1-9]\d*)?`. This will only match integers that do not start with `0`, but is otherwise identical.
2. Creates a separate rule for `0`: 

```julia
    "^0\$" |> Regex => (() -> MotionCommand(nothing, '0')),
```

which fixes a conversion error otherwise.

Now `0` works!