### PR TITLE
Defend against infinite loops

### DIFF
--- a/src/VimBindings.jl
+++ b/src/VimBindings.jl
@@ -248,7 +248,7 @@ end
 function edit_move_end(s::LE.MIState)
     buf = LE.buffer(s)
     @show typeof(buf)
-    while !eof(buf)
+    @loop_guard while !eof(buf)
         if linebreak(
             LE.char_move_right(buf))
             break
@@ -263,7 +263,7 @@ end
 
 function edit_move_start(s::LE.MIState)
     buf = LE.buffer(s)
-    while position(buf) > 0
+    @loop_guard while position(buf) > 0
         if linebreak(LE.char_move_left(buf))
             LE.char_move_right(buf)
             break

--- a/src/motion.jl
+++ b/src/motion.jl
@@ -94,7 +94,7 @@ end
 
 function right(buf::IO)::Motion
     start = position(buf)
-    while !eof(buf)
+    @loop_guard while !eof(buf)
         c = read(buf, Char)
         eof(buf) && break
         pos = position(buf)
@@ -110,7 +110,7 @@ end
 
 function left(buf::IO)::Motion
     start = position(buf)
-    while position(buf) > 0
+    @loop_guard while position(buf) > 0
         seek(buf, position(buf) - 1)
         c = peek(buf)
         (((c & 0x80) == 0) || ((c & 0xc0) == 0xc0)) && break
@@ -178,7 +178,7 @@ function word_next(buf::IO)::Motion
 
     eof(buf) && return Motion(start, start)
     last_c = read(buf, Char)
-    while !eof(buf)
+    @loop_guard while !eof(buf)
         c = read(buf, Char)
         if is_alphanumeric(last_c) && is_punctuation(c)
             break
@@ -204,7 +204,7 @@ function word_big_next(buf::IO)::Motion
 
     eof(buf) && return Motion(start, start)
     last_c = read(buf, Char)
-    while !eof(buf)
+    @loop_guard while !eof(buf)
         c = read(buf, Char)
         if is_whitespace(last_c) && !is_whitespace(c)
             break
@@ -229,11 +229,11 @@ function word_end(buf::IO)::Motion
 
     @log first_word_char = !eof(buf) && read(buf, Char)
     # find the first character of the word we will be moving to the end of
-    while !eof(buf) && position(buf) != start && is_whitespace(first_word_char)
+    @loop_guard while !eof(buf) && position(buf) != start && is_whitespace(first_word_char)
         @log first_word_char = read(buf, Char)
     end
 
-    while !eof(buf)
+    @loop_guard while !eof(buf)
         c = read(buf, Char)
         if is_punctuation(first_word_char) && !is_punctuation(c)
             LE.char_move_left(buf)
@@ -257,7 +257,7 @@ function word_back(buf::IO)::Motion
     skip(buf, -1)
     last_c = peek(buf, Char)
 
-    while position(buf) > 0
+    @loop_guard while position(buf) > 0
         c = peek(buf, Char)
         if is_alphanumeric(c) && is_punctuation(last_c)
             skip(buf, 1)
@@ -284,7 +284,7 @@ function word_big_back(buf::IO)::Motion
     skip(buf, -1)
     last_c = peek(buf, Char)
 
-    while position(buf) > 0
+    @loop_guard while position(buf) > 0
         c = peek(buf, Char)
         if is_whitespace(c) && !is_whitespace(last_c)
             skip(buf, 1)
@@ -309,11 +309,11 @@ function word_big_end(buf::IO)::Motion
 
     @log first_word_char = !eof(buf) && read(buf, Char)
     # find the first character of the word we will be moving to the end of
-    while !eof(buf) && position(buf) != start && is_whitespace(first_word_char)
+    @loop_guard while !eof(buf) && position(buf) != start && is_whitespace(first_word_char)
         @log first_word_char = read(buf, Char)
     end
 
-    while !eof(buf)
+    @loop_guard while !eof(buf)
         c = read(buf, Char)
         if is_whitespace(c)
             LE.char_move_left(buf)
@@ -331,7 +331,7 @@ function line_end(buf::IO)::Motion
     mark(buf)
     start = position(buf)
 
-    while !eof(buf)
+    @loop_guard while !eof(buf)
         c = read(buf, Char)
         if is_linebreak(c)
             break
@@ -350,7 +350,7 @@ function line_begin(buf::IO)::Motion
     # skip(buf, -1)
 
     first_line_char = start
-    while position(buf) > 0
+    @loop_guard while position(buf) > 0
         LE.char_move_left(buf)
         c = peek(buf, Char)
         if is_linebreak(c)
@@ -362,7 +362,7 @@ function line_begin(buf::IO)::Motion
     end
     if first_line_char == start
         skip(buf, 1)
-        while !eof(buf)
+        @loop_guard while !eof(buf)
             c = read(buf, Char)
             if !is_whitespace(c)
                 skip(buf, -1)
@@ -388,7 +388,7 @@ function line_zero(buf::IO)::Motion
     position(buf) == 0 && return Motion(start, start)
 
     first_line_char = start
-    while position(buf) > 0
+    @loop_guard while position(buf) > 0
         LE.char_move_left(buf)
         c = peek(buf, Char)
         if is_linebreak(c)
@@ -423,7 +423,7 @@ function find_c(buf::IO, query_c::Char)::Motion
 
     # read one char to bump us by 1
     eof(buf) || read(buf, Char)
-    while !eof(buf)
+    @loop_guard while !eof(buf)
         c = read(buf, Char)
         if c == query_c
             skip(buf, -1)
@@ -442,7 +442,7 @@ function find_c_back(buf::IO, query_c::Char)::Motion
     skip(buf, -1)
     # last_c = peek(buf, Char)
 
-    while position(buf) >= 0
+    @loop_guard while position(buf) >= 0
         c = peek(buf, Char)
         if c == query_c
             skip(buf, 1)

--- a/src/textobject.jl
+++ b/src/textobject.jl
@@ -1,6 +1,7 @@
 module TextObjects
 using Match
 using ..TextUtils
+using ..Util
 using REPL.LineEdit
 export word, line, space, WORD, textobject
 
@@ -104,7 +105,7 @@ function word(buf::IO)::Tuple{Int,Int}
     !is_word_char(peek(buf, Char)) && return (origin, origin)
 
     local start
-    while !is_object_start(buf)
+    @loop_guard while !is_object_start(buf)
         skip(buf, -1)
     end
     start = position(buf)
@@ -112,7 +113,7 @@ function word(buf::IO)::Tuple{Int,Int}
 
 
     local endd
-    while !is_object_end(buf)
+    @loop_guard while !is_object_end(buf)
         skip(buf, 1)
     end
     endd = position(buf)
@@ -132,7 +133,7 @@ function WORD(buf::IO)::Tuple{Int,Int}
     is_whitespace(peek(buf, Char)) && return (origin, origin)
 
     local start
-    while !is_non_whitespace_start(buf)
+    @loop_guard while !is_non_whitespace_start(buf)
         skip(buf, -1)
     end
     start = position(buf)
@@ -140,7 +141,7 @@ function WORD(buf::IO)::Tuple{Int,Int}
 
 
     local endd
-    while !is_non_whitespace_end(buf)
+    @loop_guard while !is_non_whitespace_end(buf)
         skip(buf, 1)
     end
     endd = position(buf)
@@ -158,7 +159,7 @@ function space(buf::IO)::Tuple{Int, Int}
     local start
     eof(buf) && return (origin, origin)
     !is_whitespace(peek(buf, Char)) && return (origin, origin)
-    while !is_whitespace_start(buf)
+    @loop_guard while !is_whitespace_start(buf)
         skip(buf, -1)
     end
     start = position(buf)
@@ -166,7 +167,7 @@ function space(buf::IO)::Tuple{Int, Int}
 
 
     local endd
-    while !is_whitespace_end(buf)
+    @loop_guard while !is_whitespace_end(buf)
         skip(buf, 1)
     end
     endd = position(buf)
@@ -183,7 +184,7 @@ function line(buf::IO)::Tuple{Int,Int}
         end
     end
 
-    while !eof(buf) && position(buf) > 0
+    @loop_guard while !eof(buf) && position(buf) > 0
         c = peek(buf, Char)
         if is_linebreak(c)
             skip(buf, 1)
@@ -195,7 +196,7 @@ function line(buf::IO)::Tuple{Int,Int}
     seek(buf, origin)
 
     # find the line end
-    while !eof(buf)
+    @loop_guard while !eof(buf)
         c = read(buf, Char)
         if is_linebreak(c)
             LE.char_move_left(buf)

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,6 +1,6 @@
 module Util
 using Sockets
-export log, getsocket, @log
+export log, getsocket, @log, @loop_guard
 import Base: show_unquoted
 
 const MAX_LOOPS = 2^16

--- a/src/util.jl
+++ b/src/util.jl
@@ -3,6 +3,33 @@ using Sockets
 export log, getsocket, @log
 import Base: show_unquoted
 
+const MAX_LOOPS = 2^16
+
+macro loop_guard(ex)
+    @assert ex.head == :while
+    loop_contents = ex.args[2]
+    @assert loop_contents.head == :block
+
+    loop_counter = gensym()
+    source = QuoteNode(__source__)
+
+    # ex is a while loop, so we insert this loop counter at the end,
+    # with a check to make sure it doesn't exceed MAX_LOOPS:
+    push!(loop_contents.args, :($loop_counter += 1))
+    push!(
+        loop_contents.args,
+        :(
+            $loop_counter > $MAX_LOOPS &&
+            (@warn("Infinite loop detected at " * string($source) * ". Exiting."); break)
+        ),
+    )
+
+    return esc(quote
+        local $loop_counter = 0
+        $ex
+    end)
+end
+
 macro log(exs...)
     blk = Expr(:block)
     loc = string("\t", __source__.file, "#", __source__.line)


### PR DESCRIPTION
There are a few while loops that for some reason seem to hit an infinite loop condition. While this PR does not solve those problems, it it creates the `@loop_guard` macro which prevents such infinite loops - instead turning them into warning messages.

When any macro-wrapped `while` loop hit 2^16 iterations without breaking, this guard will break the loop and print a warning message with debugging information.

For example, when I write:

```julia
julia> println("Hello")
```

and then hit the key strokes `F` and then `c` (to reverse find the `c` character - which does not exist), it appears to hit a while loop and freezes, leaving me unable to exit. But with this new guard rail in place, I instead see the following message:

```julia
┌ Warning: Infinite loop detected at #= /Users/mcranmer/Documents/VimBindings.jl/src/motion.jl:445 =#. Exiting.
```

followed by a return to the REPL so I can continue working.

I have wrapped every `while` loop in the library except the top-level `LE.prompt!` one (which I am guessing is the one that is supposed to be an infinite loop.).

Let me know what you think!
Cheers,
Miles