### PR TITLE
Improve performance by fixing some type inference issues

### DIFF
--- a/src/VimBindings.jl
+++ b/src/VimBindings.jl
@@ -143,7 +143,7 @@ function strike_key(c, s::LE.MIState)::StrikeKeyResult
 end
 
 function init()
-    if INITIALIZED
+    if INITIALIZED.x
         return
     end
     # enable_logging()
@@ -151,7 +151,7 @@ function init()
     @log current_task()
     repl = Base.active_repl
     trigger_insert_mode(repl.mistate)
-    global initialized = true
+    INITIALIZED.x = true
     log("initialized")
     return
 end

--- a/src/command.jl
+++ b/src/command.jl
@@ -1,6 +1,7 @@
 module Commands
 export Command, MotionCommand, OperatorCommand, LineOperatorCommand, InsertCommand,
-        SynonymCommand, SimpleMotionCommand, CompositeMotionCommand, TextObjectCommand, ReplaceCommand
+        SynonymCommand, SimpleMotionCommand, CompositeMotionCommand, TextObjectCommand, ReplaceCommand,
+        ZeroCommand
 export key
 
 abstract type Command end
@@ -156,7 +157,8 @@ function ReplaceCommand(r1, replacement :: Int)
     return ReplaceCommand(r1, string(replacement)[1])
 end
 
-
+struct ZeroCommand <: Command end
+ZeroCommand() = MotionCommand(nothing, '0')
 
 function key(cmd :: Command) :: Char
     error("method `key` not implemented for type $(typeof(cmd))")

--- a/src/command.jl
+++ b/src/command.jl
@@ -158,7 +158,7 @@ function ReplaceCommand(r1, replacement :: Int)
 end
 
 struct ZeroCommand <: Command end
-ZeroCommand() = MotionCommand(nothing, '0')
+ZeroCommand(args...) = MotionCommand(nothing, '0')
 
 function key(cmd :: Command) :: Char
     error("method `key` not implemented for type $(typeof(cmd))")

--- a/src/command.jl
+++ b/src/command.jl
@@ -158,7 +158,7 @@ function ReplaceCommand(r1, replacement :: Int)
 end
 
 struct ZeroCommand <: Command end
-ZeroCommand(args...) = MotionCommand(nothing, '0')
+ZeroCommand(args...) = ZeroCommand()
 
 function key(cmd :: Command) :: Char
     error("method `key` not implemented for type $(typeof(cmd))")

--- a/src/command.jl
+++ b/src/command.jl
@@ -30,10 +30,10 @@ end
 
 struct CompositeMotionCommand <: MotionCommand
     r1 :: Int
-    name :: AbstractString
+    name :: String
     captures :: Tuple
 end
-    
+
 CompositeMotionCommand(::Nothing, name :: AbstractString, captures :: Tuple) = CompositeMotionCommand(1, name, captures)
 CompositeMotionCommand(::Nothing, name :: AbstractString, captures :: Vararg) = CompositeMotionCommand(1, name, captures)
 
@@ -52,7 +52,7 @@ end
 
 struct TextObjectCommand <: Command
     r1 :: Int
-    name :: AbstractString
+    name :: String
 end
 
 """

--- a/src/execute.jl
+++ b/src/execute.jl
@@ -154,4 +154,6 @@ function execute(buf, command :: ReplaceCommand) :: Union{VimMode, Nothing}
     return nothing
 end
 
+execute(buf, :: ZeroCommand) = execute(buf, MotionCommand(nothing, '0'))
+
 end

--- a/src/lineeditalt.jl
+++ b/src/lineeditalt.jl
@@ -65,7 +65,7 @@ function LE.match_input(f::Function, s::Union{Nothing,LE.MIState}, term, cs::Vec
             return :ok
         end
     end
-    if state.mode == normal_mode
+    if STATE.mode == normal_mode
         return function (s, p)
             local result
             try
@@ -130,8 +130,9 @@ function LE.match_input(k::Dict{Char}, s::Union{Nothing,LE.MIState}, term::Union
 
         if is_escape
             log("yes escape")
-            if state.mode === normal_mode
+            if STATE.mode === normal_mode
                 result = strike_key("\e\e", s)
+                # TODO: Variable assigned but not used
             else
                 trigger_normal_mode(s)
             end
@@ -148,33 +149,6 @@ function LE.match_input(k::Dict{Char}, s::Union{Nothing,LE.MIState}, term::Union
         :ok
     end
     push!(cs, c)
-    # if state.mode == normal_mode
-    #     local result
-    #     try
-    #         @log result = strike_key(c, s)
-    #     catch e
-    #         @error "Error while executing vim key strike" exception = e, catch_backtrace()
-    #         result = NoAction()
-    #     end
-    #     # @log c, cs
-    #     # if result isa Fallback
-    #     # append!(cs, result.cs[begin:end-1])
-    #     cs = result.cs
-    #     x = k
-    #     for char in cs
-    #         if @log haskey(x, char)
-    #             x = x[char]
-    #         end
-    #         # @log k[char]
-    #     end
-    #     # return LE.match_input(x, s, term, cs, keymap)
-    #     # else
-    #     if result isa NoAction
-    #         return (s, p) -> :ok
-    #     end
-    #     # result isa Fallback || 
-    #     @log c, cs
-    # end
     @log escape_string(LE.input_string(s))
     @log haskey(k, c)
     key = haskey(k, c) ? c : LE.wildcard

--- a/src/lineeditalt.jl
+++ b/src/lineeditalt.jl
@@ -9,7 +9,7 @@ function LE.prompt!(term::TextTerminal, prompt::ModalInterface, s::MIState=init_
     enable_bracketed_paste(term)
     try
         activate(prompt, s, term, term)
-        if !initialized
+        if !INITIALIZED.x
             init()
             refresh_line(s)
         end

--- a/src/motion.jl
+++ b/src/motion.jl
@@ -456,7 +456,7 @@ function find_c_back(buf::IO, query_c::Char)::Motion
     return Motion(start, endd)
 end
 
-insert_motions = Dict{Char,Any}(
+const insert_motions = Dict{Char,Any}(
     'i' => (buf) -> Motion(buf),
     'I' => (buf) -> line_begin(buf),
     'a' => (buf) -> begin
@@ -475,7 +475,7 @@ insert_motions = Dict{Char,Any}(
         end
     end
 )
-simple_motions = Dict{Char,Any}(
+const simple_motions = Dict{Char,Any}(
     'h' => left,
     'l' => right,
     'j' => down,
@@ -498,7 +498,7 @@ simple_motions = Dict{Char,Any}(
     'L' => nothing
 )
 
-complex_motions = Dict{Regex,Any}(
+const complex_motions = Dict{Regex,Any}(
     r"f(.)" => (buf, char::Union{Char,Int}) -> begin
         m = find_c(buf, char)
         Motion(m, inclusive)
@@ -565,7 +565,7 @@ end
 # function double_quote(mode::NormalMode, s::LE.MIState) :: Action
 # @log vim.mode = SelectRegister()
 # end
-special_keys = Dict(
+const special_keys = Dict(
     '`' => "backtic",
     '~' => "tilde",
     '!' => "bang",
@@ -600,7 +600,7 @@ special_keys = Dict(
     '?' => "question_mark"
 )
 
-all_keys = Char[collect(keys(special_keys))
+const all_keys = Char[collect(keys(special_keys))
     collect('a':'z')
     collect('A':'Z')
     collect('0':'9')]

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -52,7 +52,7 @@ function complex_motion() :: String
 end
 const TEXTOBJECT = "$REPEAT[ai][wWsp]"
 const OPERATOR = "[ydc]"
-const RULES = OrderedDict(
+const RULES = OrderedDict{Regex,Union{Function,Type{<:Command}}}(
     # insert commands
     r"^(?<c>[aAiIoO])$" => InsertCommand,
     # Special case: `0` is a motion command:
@@ -68,7 +68,7 @@ const RULES = OrderedDict(
 )
 
 # same as above, but valid for partially completed string commands. This is to determine when the key stack should be cleared.
-partial_rules() = OrderedDict(
+partial_rules() = OrderedDict{Regex,Union{Function,Type{<:Command}}}(
     # insert commands
     r"^(?<c>[aAiIoO])" => InsertCommand,
     # Special case: `0` is a motion command:
@@ -141,6 +141,7 @@ function parse_command(s :: AbstractString) :: Union{Command, Nothing}
     end
 
     m = match(r, s)
+    m === nothing && return nothing
     args = [ parse_value(capture) for capture in m.captures ]
 
     command_type = RULES[r]

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -7,7 +7,7 @@ import ..Util.log
 
 export well_formed, matched_rule, parse_command, synonym, partial_well_formed
 
-REGS = (
+const REGS = (
     text_object = r"^.?([ai][wWsp])$",
     # complete = 
 )
@@ -37,8 +37,8 @@ Grammar for Vim's language:
         dd
         3dd
 """
-repeat = "(?:[1-9]\\d*)?"
-motion=begin
+const REPEAT = "(?:[1-9]\\d*)?"
+const MOTION = begin
     implemented_keys = join([k for k in keys(simple_motions) if k != '0'])
     "[$implemented_keys]"
 end
@@ -50,21 +50,21 @@ function complex_motion() :: String
     end
     join(patterns, "|")
 end
-textobject="$repeat[ai][wWsp]"
-operator="[ydc]"
-rules = OrderedDict(
+const TEXTOBJECT = "$REPEAT[ai][wWsp]"
+const OPERATOR = "[ydc]"
+const RULES = OrderedDict(
     # insert commands
     r"^(?<c>[aAiIoO])$" => InsertCommand,
     # Special case: `0` is a motion command:
     "^0\$" |> Regex => (() -> MotionCommand(nothing, '0')),
     # synonym commands
-    "^(?<n1>$repeat)(?<c>[xXCS])\$" |> Regex => SynonymCommand,
-    "^(?<n1>$repeat)($motion)\$" |> Regex => SimpleMotionCommand,
-    "^(?<n1>$repeat)((?|$(complex_motion())))\$" |> Regex => CompositeMotionCommand,
-    "^(?<n1>$repeat)(?<op>$operator)(?<n2>$repeat)(?|($textobject)|($motion))\$" |> Regex => OperatorCommand,
-    "^(?<n1>$repeat)(?<op>$operator)(?<n2>$repeat)((?|$(complex_motion())))\$" |> Regex => OperatorCommand,
-    "^(?<n1>$repeat)(?<op>$operator)(\\k<op>)\$" |> Regex => LineOperatorCommand,
-    "^(?<n1>$repeat)r(.)\$" |> Regex => ReplaceCommand
+    "^(?<n1>$REPEAT)(?<c>[xXCS])\$" |> Regex => SynonymCommand,
+    "^(?<n1>$REPEAT)($MOTION)\$" |> Regex => SimpleMotionCommand,
+    "^(?<n1>$REPEAT)((?|$(complex_motion())))\$" |> Regex => CompositeMotionCommand,
+    "^(?<n1>$REPEAT)(?<op>$OPERATOR)(?<n2>$REPEAT)(?|($TEXTOBJECT)|($MOTION))\$" |> Regex => OperatorCommand,
+    "^(?<n1>$REPEAT)(?<op>$OPERATOR)(?<n2>$REPEAT)((?|$(complex_motion())))\$" |> Regex => OperatorCommand,
+    "^(?<n1>$REPEAT)(?<op>$OPERATOR)(\\k<op>)\$" |> Regex => LineOperatorCommand,
+    "^(?<n1>$REPEAT)r(.)\$" |> Regex => ReplaceCommand
 )
 
 # same as above, but valid for partially completed string commands. This is to determine when the key stack should be cleared.
@@ -74,20 +74,20 @@ partial_rules() = OrderedDict(
     # Special case: `0` is a motion command:
     "^0\$" |> Regex => (() -> MotionCommand(nothing, '0')),
     # synonym commands
-    "^(?<n1>$repeat)(?<c>[xXCS])" |> Regex => SynonymCommand,
-    "^(?<n1>$repeat)($motion)" |> Regex => SimpleMotionCommand,
-    "^(?<n1>$repeat)((?|$(complex_motion())))" |> Regex => CompositeMotionCommand,
-    "^(?<n1>$repeat)(?<op>$operator)(?<n2>$repeat)(?|($textobject)|($motion))" |> Regex => OperatorCommand,
-    "^(?<n1>$repeat)(?<op>$operator)(?<n2>$repeat)((?|$(complex_motion())))" |> Regex => OperatorCommand,
-    "^(?<n1>$repeat)(?<op>$operator)(\\k<op>)" |> Regex => LineOperatorCommand,
-    "^(?<n1>$repeat)r(.)" |> Regex => ReplaceCommand
+    "^(?<n1>$REPEAT)(?<c>[xXCS])" |> Regex => SynonymCommand,
+    "^(?<n1>$REPEAT)($MOTION)" |> Regex => SimpleMotionCommand,
+    "^(?<n1>$REPEAT)((?|$(complex_motion())))" |> Regex => CompositeMotionCommand,
+    "^(?<n1>$REPEAT)(?<op>$OPERATOR)(?<n2>$REPEAT)(?|($TEXTOBJECT)|($MOTION))" |> Regex => OperatorCommand,
+    "^(?<n1>$REPEAT)(?<op>$OPERATOR)(?<n2>$REPEAT)((?|$(complex_motion())))" |> Regex => OperatorCommand,
+    "^(?<n1>$REPEAT)(?<op>$OPERATOR)(\\k<op>)" |> Regex => LineOperatorCommand,
+    "^(?<n1>$REPEAT)r(.)" |> Regex => ReplaceCommand
 )
 
 """
 Determines whether the given string is accepted as a vim command.
 """
 function well_formed(cmd :: String) :: Bool
-    for rule in keys(rules)
+    for rule in keys(RULES)
         if occursin(rule, cmd)
             return true
         end
@@ -106,7 +106,7 @@ function partial_well_formed(cmd :: String) :: Bool
 end
 
 function matched_rule(cmd :: String)
-    for rule in keys(rules)
+    for rule in keys(RULES)
         if occursin(rule, cmd)
             return rule
         end
@@ -143,7 +143,7 @@ function parse_command(s :: AbstractString) :: Union{Command, Nothing}
     m = match(r, s)
     args = [ parse_value(capture) for capture in m.captures ]
 
-    command_type = rules[r]
+    command_type = RULES[r]
     command_type(args...)
 end
 
@@ -198,7 +198,7 @@ function text_object_part(cmd :: AbstractString) :: Union{String, Nothing}
 end
 
 function verb_part(cmd :: AbstractString) :: Union{Char, Nothing}
-    reg = Regex("\\d*($operator).*")
+    reg = Regex("\\d*($OPERATOR).*")
     m = match(reg, cmd)
     if m === nothing
         return nothing

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -52,7 +52,7 @@ function complex_motion() :: String
 end
 const TEXTOBJECT = "$REPEAT[ai][wWsp]"
 const OPERATOR = "[ydc]"
-const RULES = OrderedDict{Regex,Union{Function,Type{<:Command}}}(
+const RULES = TupleDict(
     # insert commands
     r"^(?<c>[aAiIoO])$" => InsertCommand,
     # Special case: `0` is a motion command:
@@ -68,7 +68,7 @@ const RULES = OrderedDict{Regex,Union{Function,Type{<:Command}}}(
 )
 
 # same as above, but valid for partially completed string commands. This is to determine when the key stack should be cleared.
-partial_rules() = OrderedDict{Regex,Union{Function,Type{<:Command}}}(
+const PARTIAL_RULES = TupleDict(
     # insert commands
     r"^(?<c>[aAiIoO])" => InsertCommand,
     # Special case: `0` is a motion command:
@@ -96,7 +96,7 @@ function well_formed(cmd :: String) :: Bool
 end
 
 function partial_well_formed(cmd :: String) :: Bool
-    for rule in keys(partial_rules())
+    for rule in keys(PARTIAL_RULES)
         @show match(rule, cmd)
         if occursin(rule, cmd)
             return true

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,6 +1,6 @@
 module Util
 using Sockets
-export log, getsocket, @log, @loop_guard
+export log, getsocket, @log, @loop_guard, TupleDict
 import Base: show_unquoted
 
 const MAX_LOOPS = 2^16
@@ -104,5 +104,24 @@ end
 # buffer(s :: LE.MIState) = LE.buffer(s)
 
 # alpha_keymap = AnyDict()
+
+"""
+Simple NamedTuple-like type allowing custom key types (like regex)
+"""
+struct TupleDict{T1<:Tuple,T2<:Tuple}
+    keys::T1
+    values::T2
+end
+TupleDict(d::AbstractDict) = TupleDict(Tuple(keys(d)), Tuple(values(d)))
+TupleDict(pair::Pair...) = TupleDict(Tuple(first.(pair)), Tuple(last.(pair)))
+Base.keys(d::TupleDict) = d.keys
+Base.values(d::TupleDict) = d.values
+function Base.getindex(d::TupleDict, k)
+    i = findfirst(==(k), keys(d))
+    i == 0 && error("key not found")
+    return @inbounds(values(d)[i])
+end
+
+
 
 end


### PR DESCRIPTION
This gives a 2x speedup by fixing some type inference issues (found with Cthulhu.jl). In particular, some global variables were not declared constant (note that they can still be mutable even if declared constant; it simply declares the type as constant).

Before:
```julia
julia> @btime VimBindings.Parse.parse_command("d10w")
  6.717 μs (44 allocations: 1.59 KiB)
```

After:

```julia
julia> @btime VimBindings.Parse.parse_command("d10w")
  3.365 μs (35 allocations: 1.58 KiB)