### PR TITLE
Refactor logging for easier development

### DIFF
--- a/src/execute.jl
+++ b/src/execute.jl
@@ -20,15 +20,15 @@ end
 """
     Execute the given command, and return
 """
-function execute(buf, command :: MotionCommand) :: Union{VimMode, ReplAction, Nothing}
-    log("executing motion command: $(command.name)")
+function execute(buf, command::MotionCommand)::Union{VimMode,ReplAction,Nothing}
+    @debug("executing motion command: $(command.name)")
     # buf = buffer(s)
     repl_action = nothing
     for iteration in 1:command.r1
         # call the command's function to generate the motion object
-        @log motion = gen_motion(buf, command)
+        @debug motion = gen_motion(buf, command)
         if is_stationary(motion)
-            @log repl_action = @match key(command) begin
+            @debug repl_action = @match key(command) begin
                 'j' => history_down
                 'k' => history_up
             end
@@ -39,7 +39,7 @@ function execute(buf, command :: MotionCommand) :: Union{VimMode, ReplAction, No
     end
     return repl_action
 end
-function execute(buf, command :: LineOperatorCommand) :: Union{VimMode, Nothing}
+function execute(buf, command::LineOperatorCommand)::Union{VimMode,Nothing}
     local op_fn = nothing
     for r in 1:command.r1
         # buf = buffer(s)
@@ -54,7 +54,7 @@ function execute(buf, command :: LineOperatorCommand) :: Union{VimMode, Nothing}
     return nothing
 end
 
-function execute(buf, command :: InsertCommand) :: Union{VimMode, Nothing}
+function execute(buf, command::InsertCommand)::Union{VimMode,Nothing}
     # cmds = [aAiIoO]
     # buf = buffer(s)
     motion = @match command.c begin
@@ -96,10 +96,10 @@ function execute(buf, command :: InsertCommand) :: Union{VimMode, Nothing}
     return insert_mode
 end
 
-function execute(buf, command :: OperatorCommand) :: Union{VimMode, Nothing}
+function execute(buf, command::OperatorCommand)::Union{VimMode,Nothing}
     # *5*d2w
-    log(command)
-    @log op_fn = operator_fn(command.operator)
+    @debug(command)
+    @debug op_fn = operator_fn(command.operator)
     # From neovim help ":h cw"
     # Special case: When the cursor is in a word, "cw" and "cW" do not include the
     # white space after a word, they only change up to the end of the word.  This is
@@ -109,18 +109,22 @@ function execute(buf, command :: OperatorCommand) :: Union{VimMode, Nothing}
     if command.operator == 'c' && command.action.name in ['w', 'W']
         # in the middle of a word
         if at_junction_type(buf, In{>:Word})
-            new_name = if command.action.name == 'w' 'e' else 'E' end
-            log("altering 'c$(command.action)' command to 'c$new_name'")
+            new_name = if command.action.name == 'w'
+                'e'
+            else
+                'E'
+            end
+            @debug("altering 'c$(command.action)' command to 'c$new_name'")
             command = OperatorCommand(command.r1, command.operator, command.action.r1, new_name)
         end
     end
     for r1 in 1:command.r1
         # TODO the iteration on `action.r1` should probably happen in `gen_motion`
         for r2 in 1:command.action.r1
-            @log r2
-            @log motion = gen_motion(buf, command.action)
-            # @log result = eval(Expr(:call, op_fn, buf, motion))
-            @log result = op_fn(buf, motion)
+            @debug r2
+            @debug motion = gen_motion(buf, command.action)
+            # @debug result = eval(Expr(:call, op_fn, buf, motion))
+            @debug result = op_fn(buf, motion)
         end
     end
     if op_fn == change
@@ -129,7 +133,7 @@ function execute(buf, command :: OperatorCommand) :: Union{VimMode, Nothing}
     return nothing
 end
 
-function execute(buf, command :: SynonymCommand) :: Union{VimMode, Nothing}
+function execute(buf, command::SynonymCommand)::Union{VimMode,Nothing}
     synonyms = Dict(
         'x' => "dl",
         'X' => "dh",
@@ -138,14 +142,14 @@ function execute(buf, command :: SynonymCommand) :: Union{VimMode, Nothing}
         'S' => "cc"
     )
     new_command = parse_command("$(command.r1)$(synonyms[command.operator])")
-    
+
     return execute(buf, new_command)
 end
 
-function execute(buf, command :: ReplaceCommand) :: Union{VimMode, Nothing}
+function execute(buf, command::ReplaceCommand)::Union{VimMode,Nothing}
     inserted = 0
     for r1 in 1:command.r1
-        delete(buf, right(buf))        
+        delete(buf, right(buf))
         inserted += LE.edit_insert(buf, command.replacement)
     end
     if inserted > 0

--- a/src/motion.jl
+++ b/src/motion.jl
@@ -227,10 +227,10 @@ function word_end(buf::IO)::Motion
     # move at least 1 (or else it is EOF)
     read(buf, Char)
 
-    @log first_word_char = !eof(buf) && read(buf, Char)
+    @debug first_word_char = !eof(buf) && read(buf, Char)
     # find the first character of the word we will be moving to the end of
     @loop_guard while !eof(buf) && position(buf) != start && is_whitespace(first_word_char)
-        @log first_word_char = read(buf, Char)
+        @debug first_word_char = read(buf, Char)
     end
 
     @loop_guard while !eof(buf)
@@ -244,8 +244,8 @@ function word_end(buf::IO)::Motion
         end
     end
     LE.char_move_left(buf)
-    @log endd = position(buf)
-    @log typeof(endd)
+    @debug endd = position(buf)
+    @debug typeof(endd)
     reset(buf)
     return Motion(start, endd, inclusive)
 end
@@ -307,10 +307,10 @@ function word_big_end(buf::IO)::Motion
     # move at least 1 (or else it is EOF)
     read(buf, Char)
 
-    @log first_word_char = !eof(buf) && read(buf, Char)
+    @debug first_word_char = !eof(buf) && read(buf, Char)
     # find the first character of the word we will be moving to the end of
     @loop_guard while !eof(buf) && position(buf) != start && is_whitespace(first_word_char)
-        @log first_word_char = read(buf, Char)
+        @debug first_word_char = read(buf, Char)
     end
 
     @loop_guard while !eof(buf)
@@ -321,8 +321,8 @@ function word_big_end(buf::IO)::Motion
         end
     end
     LE.char_move_left(buf)
-    @log endd = position(buf)
-    @log typeof(endd)
+    @debug endd = position(buf)
+    @debug typeof(endd)
     reset(buf)
     return Motion(start, endd, inclusive)
 end
@@ -529,7 +529,7 @@ function gen_motion(buf, cmd::SimpleMotionCommand)::Motion
     fn = if cmd.name in keys(simple_motions)
         simple_motions[cmd.name]
     else
-        log("$(cmd.name) has no mapped function")
+        @debug("$(cmd.name) has no mapped function")
         (buf) -> Motion(buf)
     end
     # call the command's function to generate the motion object
@@ -563,7 +563,7 @@ end
 
 
 # function double_quote(mode::NormalMode, s::LE.MIState) :: Action
-# @log vim.mode = SelectRegister()
+# @debug vim.mode = SelectRegister()
 # end
 special_keys = Dict(
     '`' => "backtic",

--- a/src/operator.jl
+++ b/src/operator.jl
@@ -28,7 +28,7 @@ end
 function delete(buf::IO, motion::Motion) #, motion_type :: MotionType)
     yank(buf, motion)
     move(buf, motion) #, motion_type)
-    @log LE.edit_splice!(buf, min(motion) => max(motion))
+    @debug LE.edit_splice!(buf, min(motion) => max(motion))
     return nothing
 end
 

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -3,12 +3,12 @@ import DataStructures: OrderedDict
 using ..Commands
 using ..Motions
 using ..Util
-import ..Util.log
+import ..Util.@debug
 
 export well_formed, matched_rule, parse_command, synonym, partial_well_formed
 
 REGS = (
-    text_object = r"^.?([ai][wWsp])$",
+    text_object=r"^.?([ai][wWsp])$",
     # complete = 
 )
 """
@@ -38,20 +38,20 @@ Grammar for Vim's language:
         3dd
 """
 repeat = "(?:[1-9]\\d*)?"
-motion=begin
+motion = begin
     implemented_keys = join([k for k in keys(simple_motions) if k != '0'])
     "[$implemented_keys]"
 end
 # motions with multiple keystrokes e.g. 'fx'
-function complex_motion() :: String
+function complex_motion()::String
     local motion_regexes = keys(complex_motions) |> collect
     patterns = map(motion_regexes) do regex
         regex.pattern
     end
     join(patterns, "|")
 end
-textobject="$repeat[ai][wWsp]"
-operator="[ydc]"
+textobject = "$repeat[ai][wWsp]"
+operator = "[ydc]"
 rules = OrderedDict(
     # insert commands
     r"^(?<c>[aAiIoO])$" => InsertCommand,
@@ -86,7 +86,7 @@ partial_rules() = OrderedDict(
 """
 Determines whether the given string is accepted as a vim command.
 """
-function well_formed(cmd :: String) :: Bool
+function well_formed(cmd::String)::Bool
     for rule in keys(rules)
         if occursin(rule, cmd)
             return true
@@ -95,7 +95,7 @@ function well_formed(cmd :: String) :: Bool
     return false
 end
 
-function partial_well_formed(cmd :: String) :: Bool
+function partial_well_formed(cmd::String)::Bool
     for rule in keys(partial_rules())
         @show match(rule, cmd)
         if occursin(rule, cmd)
@@ -105,7 +105,7 @@ function partial_well_formed(cmd :: String) :: Bool
     return false
 end
 
-function matched_rule(cmd :: String)
+function matched_rule(cmd::String)
     for rule in keys(rules)
         if occursin(rule, cmd)
             return rule
@@ -117,7 +117,7 @@ end
 """
     Get the typed value of `item`
 """
-function parse_value(item :: Union{Nothing, AbstractString}) :: Union{Integer, Char, AbstractString, Nothing}
+function parse_value(item::Union{Nothing,AbstractString})::Union{Integer,Char,AbstractString,Nothing}
     if item === nothing || isempty(item)
         return nothing
     end
@@ -133,15 +133,15 @@ end
 """
     Attempt to parse a command, return nothing if `s` could not be parsed into a command
 """
-function parse_command(s :: AbstractString) :: Union{Command, Nothing}
+function parse_command(s::AbstractString)::Union{Command,Nothing}
     r = matched_rule(s)
     if r === nothing
-        log("command not well formed", s)
+        @debug("command not well formed", s)
         return nothing
     end
 
     m = match(r, s)
-    args = [ parse_value(capture) for capture in m.captures ]
+    args = [parse_value(capture) for capture in m.captures]
 
     command_type = rules[r]
     command_type(args...)
@@ -152,18 +152,18 @@ end
     Return a struct corresponding to a regex match's Vim command
 """
 
-function synonym(command :: SynonymCommand) :: Command
+function synonym(command::SynonymCommand)::Command
     synonyms = Dict(
-            'x' => "dl",
-            'X' => "dh"
-        )
+        'x' => "dl",
+        'X' => "dh"
+    )
     return parse_command("$(command.r1)$(synonyms[command.operator])")
 
 end
-    
 
 
-function lookup_synonym(n :: Integer, c :: Char)
+
+function lookup_synonym(n::Integer, c::Char)
 end
 
 
@@ -174,8 +174,8 @@ end
 #     return m
 # end
 
-function Base.Dict(m :: RegexMatch)
-    d = OrderedDict{Symbol, Any}()
+function Base.Dict(m::RegexMatch)
+    d = OrderedDict{Symbol,Any}()
     idx_to_capture_name = Base.PCRE.capture_names(m.regex.regex)
     if !isempty(m.captures)
         for i = 1:Base.length(m.captures)
@@ -189,7 +189,7 @@ end
 
 
 
-function text_object_part(cmd :: AbstractString) :: Union{String, Nothing}
+function text_object_part(cmd::AbstractString)::Union{String,Nothing}
     m = match(REGS.text_object, cmd)
     if m === nothing
         return nothing
@@ -197,7 +197,7 @@ function text_object_part(cmd :: AbstractString) :: Union{String, Nothing}
     return m.captures[1]
 end
 
-function verb_part(cmd :: AbstractString) :: Union{Char, Nothing}
+function verb_part(cmd::AbstractString)::Union{Char,Nothing}
     reg = Regex("\\d*($operator).*")
     m = match(reg, cmd)
     if m === nothing

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,7 +1,5 @@
 module Util
-using Sockets
-export @debug, getsocket, @debug, @loop_guard
-import Base: show_unquoted
+export @loop_guard
 
 const MAX_LOOPS = 2^16
 
@@ -29,85 +27,4 @@ macro loop_guard(ex)
         $ex
     end)
 end
-
-macro @debug(exs...)
-    blk = Expr(:block)
-    loc = string("\t", __source__.file, "#", __source__.line)
-    for ex in exs
-        push!(blk.args, :(println(getsocket(),
-            $(sprint(show_unquoted, ex) * " = "),
-            repr(begin
-                value = $(esc(ex))
-            end),
-            "\n",
-            $loc,
-            "\n",
-        )))
-    end
-    isempty(exs) || push!(blk.args, :value)
-    return blk
-end
-
-# macro @debug(str)
-#     blk = Expr(:block)
-#     loc = string("\t", __source__.file, "#", __source__.line)
-#     push!(blk.args, :(println(getsocket(),
-#                               # repr(begin value=$(esc(str)) end),
-#                               $str,
-#                               "\n",
-#                               $loc,
-#                               "\n",
-#                               )))
-#     push!(blk.args, :value)
-#     return blk
-# end
-
-
-# TODO this is terrible to overload
-function Base.@debug(s...)
-    println(getsocket(), s...)
-end
-
-function __init__()
-    global socket = devnull
-end
-function enable_logging()
-    global socket = connect(1234)
-end
-
-function getsocket()
-    if @isdefined(socket)
-        return socket
-    end
-    return devnull
-end
-
-function Base.@debug(any::Any)
-    socket = getsocket()
-    println(socket, any)
-end
-
-
-function test_bind()
-
-end
-
-# 'j' => (s::LE.MIState, o...)->LE.edit_move_down(s),
-
-macro bindkey(c)
-    # char = ($(esc(c)))
-    # char = esc(c)
-    # @show sym = Symbol(char)
-    return :(
-        () -> eval(Expr(:call, Symbol($(esc(c))))))
-    # pair item 2
-    # (s::LE.MIState, o...)->begin
-    # @show Symbol($(esc(c)))
-    # Expr(:call, Symbol($(esc(c))),(VB.mode, esc(s)))
-end
-
-# buffer(s :: LE.MIState) = LE.buffer(s)
-
-# alpha_keymap = AnyDict()
-
 end

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,6 +1,6 @@
 module Util
 using Sockets
-export log, getsocket, @log, @loop_guard
+export @debug, getsocket, @debug, @loop_guard
 import Base: show_unquoted
 
 const MAX_LOOPS = 2^16
@@ -30,23 +30,25 @@ macro loop_guard(ex)
     end)
 end
 
-macro log(exs...)
+macro @debug(exs...)
     blk = Expr(:block)
     loc = string("\t", __source__.file, "#", __source__.line)
     for ex in exs
         push!(blk.args, :(println(getsocket(),
-                                  $(sprint(show_unquoted,ex)*" = "),
-                                  repr(begin value=$(esc(ex)) end),
-                                  "\n",
-                                  $loc,
-                                  "\n",
-                                  )))
+            $(sprint(show_unquoted, ex) * " = "),
+            repr(begin
+                value = $(esc(ex))
+            end),
+            "\n",
+            $loc,
+            "\n",
+        )))
     end
     isempty(exs) || push!(blk.args, :value)
     return blk
 end
 
-# macro log(str)
+# macro @debug(str)
 #     blk = Expr(:block)
 #     loc = string("\t", __source__.file, "#", __source__.line)
 #     push!(blk.args, :(println(getsocket(),
@@ -62,7 +64,7 @@ end
 
 
 # TODO this is terrible to overload
-function Base.log(s...)
+function Base.@debug(s...)
     println(getsocket(), s...)
 end
 
@@ -80,7 +82,7 @@ function getsocket()
     return devnull
 end
 
-function Base.log(any::Any)
+function Base.@debug(any::Any)
     socket = getsocket()
     println(socket, any)
 end
@@ -97,11 +99,11 @@ macro bindkey(c)
     # char = esc(c)
     # @show sym = Symbol(char)
     return :(
-        ()->eval(Expr(:call, Symbol($(esc(c))))))
-         # pair item 2
-         # (s::LE.MIState, o...)->begin
-         # @show Symbol($(esc(c)))
-         # Expr(:call, Symbol($(esc(c))),(VB.mode, esc(s)))
+        () -> eval(Expr(:call, Symbol($(esc(c))))))
+    # pair item 2
+    # (s::LE.MIState, o...)->begin
+    # @show Symbol($(esc(c)))
+    # Expr(:call, Symbol($(esc(c))),(VB.mode, esc(s)))
 end
 
 # buffer(s :: LE.MIState) = LE.buffer(s)


### PR DESCRIPTION
Don't overwrite `Base.log`. Horrible for so many reasons.

This PR is to implement a more accessible logging solution for debugging.

- [x] Remove calls to `log`
- [ ] Implement `AbstractLogger`