### PR TITLE
Improve type inference and speed

### DIFF
--- a/src/command.jl
+++ b/src/command.jl
@@ -189,12 +189,15 @@ ReplaceCommand(1, 'c')
 ```
 is equivalent to the code:
 ```
-command_constructor((x...) -> ReplaceCommand(x...), ParseValue(1), ParseValue('c'))
+command_constructor(ReplaceCommand, ParseValue(1), ParseValue('c'))
 ```
 The reason to use this second approach is better type stability.
 (Though, a refactor with a single type-stable command struct would be better.)
 """
-function command_constructor(f::F, parse_values::ParseValue...) where F
+function command_constructor(::Type{C}, parse_values::ParseValue...) where {C<:Command}
+    return command_constructor((x...) -> C(x...), parse_values...)::C
+end
+function command_constructor(f::F, parse_values::ParseValue...) where {F<:Function}
     if parse_values[1].type == :nothing
         return command_constructor((x...) -> f(nothing, x...), parse_values[2:end]...)
     elseif parse_values[1].type == :int
@@ -208,7 +211,7 @@ function command_constructor(f::F, parse_values::ParseValue...) where F
     end
 end
 # Finally, we call it:
-command_constructor(f::F) where F = f()::Command
+command_constructor(f::F) where {F<:Function} = f()::Command
 
 
 end

--- a/src/command.jl
+++ b/src/command.jl
@@ -180,7 +180,20 @@ ParseValue(i::Int) = ParseValue(type=:int, i=i)
 ParseValue(c::Char) = ParseValue(type=:char, c=c)
 ParseValue(s::AbstractString) = ParseValue(type=:string, s=s)
 
-"""This function unpacks the parsed values into a `Command` object"""
+"""
+This function unpacks the parsed values into a `Command` object.
+
+For example, the code:
+```
+ReplaceCommand(1, 'c')
+```
+is equivalent to the code:
+```
+command_constructor((x...) -> ReplaceCommand(x...), ParseValue(1), ParseValue('c'))
+```
+The reason to use this second approach is better type stability.
+(Though, a refactor with a single type-stable command struct would be better.)
+"""
 function command_constructor(f::F, parse_values::ParseValue...) where F
     if parse_values[1].type == :nothing
         return command_constructor((x...) -> f(nothing, x...), parse_values[2:end]...)

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -145,7 +145,7 @@ function parse_command(s :: AbstractString) :: Union{Command, Nothing}
     m === nothing && return nothing
     m::RegexMatch
     dtype = RULES[r]
-    return command_constructor((x...) -> dtype(x...), parse_value.(m.captures)...)
+    return command_constructor(dtype, parse_value.(m.captures)...)
 end
 
 

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -117,17 +117,17 @@ end
 """
     Get the typed value of `item`
 """
-function parse_value(item :: Union{Nothing, AbstractString}) :: Union{Integer, Char, AbstractString, Nothing}
+function parse_value(item :: Union{Nothing, AbstractString}) :: ParseValue
     if item === nothing || isempty(item)
-        return nothing
+        return ParseValue(nothing)
     end
     if match(r"^\d+$", item) !== nothing
-        return parse(Int, item)
+        return ParseValue(parse(Int, item))
     end
     if length(item) == 1
-        return item[1]
+        return ParseValue(item[1])
     end
-    return item
+    return ParseValue(item)
 end
 
 """
@@ -144,7 +144,8 @@ function parse_command(s :: AbstractString) :: Union{Command, Nothing}
     m = match(r, s)
     m === nothing && return nothing
     m::RegexMatch
-    return RULES[r](parse_value.(m.captures)...)
+    dtype = RULES[r]
+    return command_constructor((x...) -> dtype(x...), parse_value.(m.captures)...)
 end
 
 

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -2,6 +2,7 @@
 # import VimBindings: verb_part, text_object_part, well_formed, parse_value
 import VimBindings.Parse: verb_part, text_object_part, well_formed, parse_value
 using VimBindings.Commands
+import VimBindings.Commands: ParseValue
 using VimBindings.Parse
 import VimBindings.Parse: command, parse_command
 
@@ -29,11 +30,11 @@ import VimBindings.Parse: command, parse_command
 
 
 @testset "parse values" begin
-    @test Parse.parse_value("10") == 10
-    @test Parse.parse_value("0") == 0
-    @test Parse.parse_value(".") == '.'
-    @test Parse.parse_value("asdf") == "asdf"
-    @test Parse.parse_value("10ten") == "10ten"
+    @test Parse.parse_value("10") == ParseValue(10)
+    @test Parse.parse_value("0") == ParseValue(0)
+    @test Parse.parse_value(".") == ParseValue('.')
+    @test Parse.parse_value("asdf") == ParseValue("asdf")
+    @test Parse.parse_value("10ten") == ParseValue("10ten")
 end
 @testset "verbs from strings" begin
     @test verb_part("dw") == 'd'
@@ -76,11 +77,11 @@ end
 end
 
 @testset "parse specific values" begin
-    @test parse_value("10") == 10
-    @test parse_value("") === nothing
-    @test parse_value("d") == 'd'
-    @test parse_value("aw") == "aw"
-    @test parse_value(nothing) === nothing
+    @test parse_value("10") == ParseValue(10)
+    @test parse_value("") == ParseValue(nothing)
+    @test parse_value("d") == ParseValue('d')
+    @test parse_value("aw") == ParseValue("aw")
+    @test parse_value(nothing) == ParseValue(nothing)
 end
 
 @testset "parse commands into parts" begin


### PR DESCRIPTION
This gets another 2x in performance by making the parsed values return a static type:

```julia
Base.@kwdef struct ParseValue
    type::Symbol
    i::Int=1
    c::Char=' '
    s::String=""
end
```

which makes the Julia compiler happy as it doesn't have to do type inference itself.

This also creates a function `command_constructor` which basically unpacks these recursively in function barriers. (https://docs.julialang.org/en/v1/manual/performance-tips/#kernel-functions).

There are still some type inference issues because `parse_command` is returning one of many possible types, but this improves over baseline.