### PR TITLE
Clear key stack when stack invalid

### DIFF
--- a/src/VimBindings.jl
+++ b/src/VimBindings.jl
@@ -74,7 +74,7 @@ function strike_key(c, s::LE.MIState)::StrikeKeyResult
 
     s_cmd = String(KEY_STACK)
     # keys to copy from `mode`
-    fallback_keys = [
+    fallback_keys = (
         # enter
         "\r",
         # tab
@@ -103,7 +103,7 @@ function strike_key(c, s::LE.MIState)::StrikeKeyResult
         "\x04",
         # C-l
         "\f"
-    ]
+    )
 
     s_cmd in fallback_keys && begin
         @debug "falling back for command" command=escape_string(s_cmd)

--- a/src/VimBindings.jl
+++ b/src/VimBindings.jl
@@ -135,13 +135,15 @@ function strike_key(c, s::LE.MIState)::StrikeKeyResult
             end
         end
         return VimAction()
-    else
+    end
+    if !partial_well_formed(s_cmd)
         @debug("WARN: command not well formed!")
         @debug KEY_STACK
-        # TODO if command is still a possible match, don't clear the stack.
-        #  In other words, only clear the stack if the stack is definitely invalid.
-        return NoAction()
+        empty!(KEY_STACK)
     end
+    # If command is still a possible match, don't clear the stack.
+    # In other words, only clear the stack if the stack is definitely invalid.
+    return NoAction()
 end
 
 function init()

--- a/src/motion.jl
+++ b/src/motion.jl
@@ -8,8 +8,8 @@ using ..Util
 using ..Commands
 using Match
 
-export Motion, MotionType, simple_motions, complex_motions, insert_motions, gen_motion, is_stationary,
-    down, up, word_next, word_big_next, word_end, word_back,
+export Motion, MotionType, simple_motions, complex_motions, partial_complex_motions, insert_motions, gen_motion,
+    is_stationary, down, up, word_next, word_big_next, word_end, word_back,
     word_big_back, word_big_end, line_end, line_begin, line_zero,
     find_c, find_c_back, get_safe_name, all_keys, special_keys, exclusive, inclusive, endd,
     left, right
@@ -522,6 +522,13 @@ const complex_motions = Dict{Regex,Any}(
     #     Motion(m, inclusive)
     # end,
 )
+const partial_complex_motions = (
+    r"f",
+    r"F",
+    r"t",
+    r"T"
+)
+
 """
     Generate a Motion object for the given `name`
 """

--- a/src/motion.jl
+++ b/src/motion.jl
@@ -523,10 +523,10 @@ const complex_motions = Dict{Regex,Any}(
     # end,
 )
 const partial_complex_motions = (
-    r"f",
-    r"F",
-    r"t",
-    r"T"
+    r"f(.)?",
+    r"F(.)?",
+    r"t(.)?",
+    r"T(.)?"
 )
 
 """

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -52,11 +52,13 @@ function complex_motion(partial::Bool=false)::String
 end
 const TEXTOBJECT = "$REPEAT[ai][wWsp]"
 const PARTIALTEXTOBJECT = "$REPEAT[ai]([wWsp])?"
+const DELETECHARS = "[xXDCS]"
+const INSERTCHARS = "[aAiIoO]"
 const OPERATOR = "[ydc]"
 const RULES = TupleDict(
-    r"^(?<c>[aAiIoO])$" => InsertCommand, # insert commands
+    "^(?<c>$INSERTCHARS)\$" |> Regex => InsertCommand, # insert commands
     "^0\$" |> Regex => ZeroCommand, # Special case: `0` is a motion command
-    "^(?<n1>$REPEAT)(?<c>[xXDCS])\$" |> Regex => SynonymCommand,
+    "^(?<n1>$REPEAT)(?<c>$DELETECHARS)\$" |> Regex => SynonymCommand,
     "^(?<n1>$REPEAT)($MOTION)\$" |> Regex => SimpleMotionCommand,
     "^(?<n1>$REPEAT)((?|$(complex_motion())))\$" |> Regex => CompositeMotionCommand,
     "^(?<n1>$REPEAT)(?<op>$OPERATOR)(?<n2>$REPEAT)(?|($TEXTOBJECT)|($MOTION))\$" |> Regex => OperatorCommand,
@@ -67,15 +69,15 @@ const RULES = TupleDict(
 
 # same as above, but valid for partially completed string commands. This is to determine when the key stack should be cleared.
 const PARTIAL_RULES = (
-    r"^[aAiIoO]?$",  # InsertCommand
+    "^$INSERTCHARS?\$" |> Regex,  # InsertCommand
     "^0?\$" |> Regex,  # ZeroCommand
-    "^$(REPEAT)([xXCS])?\$" |> Regex,  # SynonymCommand
-    "^$(REPEAT)($MOTION)?\$" |> Regex,  # SimpleMotionCommand
-    "^$(REPEAT)($(complex_motion(true)))?\$" |> Regex,  # CompositeMotionCommand
-    "^$(REPEAT)($(OPERATOR)($(REPEAT)(($(PARTIALTEXTOBJECT))|($(MOTION)))?)?)?\$" |> Regex,  # OperatorCommand
-    "^$(REPEAT)($(OPERATOR)($(REPEAT)($(complex_motion(true)))?)?)?\$" |> Regex,  # OperatorCommand (2)
-    "^$(REPEAT)((?<op>$(OPERATOR))(\\k<op>)?)?\$" |> Regex,  # LineOperatorCommand
-    "^$(REPEAT)(r(.)?)?\$" |> Regex  # ReplaceCommand
+    "^$REPEAT($DELETECHARS)?\$" |> Regex,  # SynonymCommand
+    "^$REPEAT($MOTION)?\$" |> Regex,  # SimpleMotionCommand
+    "^$REPEAT($(complex_motion(true)))?\$" |> Regex,  # CompositeMotionCommand
+    "^$REPEAT($OPERATOR($REPEAT(($PARTIALTEXTOBJECT)|($MOTION))?)?)?\$" |> Regex,  # OperatorCommand
+    "^$REPEAT($OPERATOR($REPEAT($(complex_motion(true)))?)?)?\$" |> Regex,  # OperatorCommand (2)
+    "^$REPEAT((?<op>$OPERATOR)(\\k<op>)?)?\$" |> Regex,  # LineOperatorCommand
+    "^$REPEAT(r(.)?)?\$" |> Regex  # ReplaceCommand
 )
 # Note that many of these are redundant. This is written for consistency.
 

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -69,15 +69,15 @@ const RULES = TupleDict(
 
 # same as above, but valid for partially completed string commands. This is to determine when the key stack should be cleared.
 const PARTIAL_RULES = (
-    "^$INSERTCHARS?\$" |> Regex,  # InsertCommand
+    "^(?<c>$INSERTCHARS)?\$" |> Regex,  # InsertCommand
     "^0?\$" |> Regex,  # ZeroCommand
-    "^$REPEAT($DELETECHARS)?\$" |> Regex,  # SynonymCommand
-    "^$REPEAT($MOTION)?\$" |> Regex,  # SimpleMotionCommand
-    "^$REPEAT($(complex_motion(true)))?\$" |> Regex,  # CompositeMotionCommand
-    "^$REPEAT($OPERATOR($REPEAT(($PARTIALTEXTOBJECT)|($MOTION))?)?)?\$" |> Regex,  # OperatorCommand
-    "^$REPEAT($OPERATOR($REPEAT($(complex_motion(true)))?)?)?\$" |> Regex,  # OperatorCommand (2)
-    "^$REPEAT((?<op>$OPERATOR)(\\k<op>)?)?\$" |> Regex,  # LineOperatorCommand
-    "^$REPEAT(r(.)?)?\$" |> Regex  # ReplaceCommand
+    "^(?<n1>$REPEAT)(?<c>$DELETECHARS)?\$" |> Regex,  # SynonymCommand
+    "^(?<n1>$REPEAT)($MOTION)?\$" |> Regex,  # SimpleMotionCommand
+    "^(?<n1>$REPEAT)((?|$(complex_motion(true))))?\$" |> Regex,  # CompositeMotionCommand
+    "^(?<n1>$REPEAT)((?<op>$OPERATOR)((?<n2>$REPEAT)((?|($PARTIALTEXTOBJECT)|($MOTION)))?)?)?\$" |> Regex,  # OperatorCommand
+    "^(?<n1>$REPEAT)((?<op>$OPERATOR)((?<n2>$REPEAT)((?|$(complex_motion(true))))?)?)?\$" |> Regex,  # OperatorCommand (2)
+    "^(?<n1>$REPEAT)((?<op>$OPERATOR)(\\k<op>)?)?\$" |> Regex,  # LineOperatorCommand
+    "^(?<n1>$REPEAT)(r(.)?)?\$" |> Regex  # ReplaceCommand
 )
 # Note that many of these are redundant. This is written for consistency.
 

--- a/src/pkgtools.jl
+++ b/src/pkgtools.jl
@@ -6,7 +6,7 @@ Tools for running or testing the package. This module is meant for code that is
 The end of this file contains precompilation code
 """
 module PkgTools
-import ..VimBuffer, ..parse_command, ..testbuf, ..execute
+import ..VimBuffer, ..parse_command, ..testbuf, ..execute, ..well_formed, ..partial_well_formed
 import ..TextUtils: junction_type, TextChar, is_object_start, is_whitespace_start,
     is_non_whitespace_start, is_object_end, is_non_whitespace_end, is_whitespace_end
 using Combinatorics
@@ -14,7 +14,7 @@ using Combinatorics
 const TEST_STRING = """abcdefghijklmnopqrstuvwxyz "' 0987654321 A B C D E F G H| I J K L M N O P Q R S T U V W X Y Z 98 76 54 32 21 !@#%^9^&*() abcdefghijklmnopqrstuvwxyz '" 0987654321"""
 
 
-function partial_vim_commands_list()::Vector{String}
+function some_vim_commands()::Vector{String}
     s = """
         h j k l
         3h 3j 3k 3l
@@ -29,7 +29,7 @@ Convenience function to return each vim command alongside a pre-constructed
     vim buffer
 """
 commands_and_buffers()::Vector{Tuple{String,VimBuffer}} =
-    map(partial_vim_commands_list()) do cmd
+    map(some_vim_commands()) do cmd
         (cmd, testbuf(TEST_STRING))
     end
 
@@ -66,14 +66,14 @@ end
 end
 
 using PrecompileTools
-
-# PrecompileTools.verbose[] = true
 # precompilation
 @setup_workload begin
     commands = PkgTools.commands_and_buffers()
-
     @compile_workload begin
         for (cmd, buf) in commands
+            well_formed(cmd)
+            partial_well_formed(cmd)
+            
             PkgTools.run(cmd, buf)
         end
 

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -59,7 +59,9 @@ end
 end
 @testset "validating commands" begin
     well_formed_cmds = (
-        "daw", "dd", "yy", "5dd", "yy", "h", "l", "5l", "4h", "10dd"
+        "daw", "dd", "yy", "5dd", "yy", "h", "l", "5l", "4h", "10dd", "x",
+        "ri", "ra", "r0", "r7", "5fd", "5Fd", "ciw", "dw", "2dw", "j", "k",
+        "I", "O", "o", "10D", "20x", "2dfe", "2cFk", "2dF0"
     )
     poorly_formed_cmds = (
         "aw", "5d5w5", "yd", "cd"
@@ -80,6 +82,9 @@ end
                 cmd_stub = cmd[1:cmd_end]
                 @test partial_well_formed(cmd_stub) || @show cmd_stub
             end
+        end
+        for cmd in poorly_formed_cmds
+            @test !partial_well_formed(cmd) || @show cmd
         end
         # TODO: Remove these when the commands are implemented:
         @test !partial_well_formed("u")
@@ -110,18 +115,18 @@ end
     @test well_formed(cmd) == true
     r = matched_rule(cmd)
     @test parse_command(cmd) == OperatorCommand(1,
-                                                    'd',
-                                                    10,
-                                                    'w')
+        'd',
+        10,
+        'w')
 
 
 end
 
 @testset "parse line operator commands" begin
     @test parse_command("5dd") == LineOperatorCommand(5,
-                                                      'd')
+        'd')
     @test parse_command("100yy") == LineOperatorCommand(100,
-                                                        'y')
+        'y')
 
     @test parse_command("100yd") === nothing
     @test parse_command("yy") === LineOperatorCommand(1, 'y')

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -73,9 +73,10 @@ end
         end
     end
     @testset "Partially well formed commands" begin
+        # Well formed commands should be partially well formed
+        #  when sliced from their start to any point in the middle.
         for cmd in well_formed_cmds
-            length(cmd) <= 1 && continue
-            for cmd_end in 2:length(cmd)
+            for cmd_end in 1:length(cmd)
                 cmd_stub = cmd[1:cmd_end]
                 @test partial_well_formed(cmd_stub) || @show cmd_stub
             end


### PR DESCRIPTION
Just like in Vim, when you type an invalid command, this will clear the key stack and start again. Rather than needing to hit the escape key manually. I think this will be very helpful for new users.

This implements the behavior by completing the `partial_well_formed` function so that it checks whether a command *could be* well formed in the future. If it is impossible for a command to be well formed, it returns `false`, and the key stack is cleared.

This also adds some unit tests. (But please double check the regexp's before merging as it was a bit tricky to get them working. The mistake likelihood seems fairly high)

Fixes #38