### PR TITLE
fix: Remove Dict method overriding Base.Dict method

### DIFF
--- a/src/parse.jl
+++ b/src/parse.jl
@@ -180,20 +180,6 @@ end
 #     return m
 # end
 
-function Base.Dict(m::RegexMatch)
-    d = OrderedDict{Symbol,Any}()
-    idx_to_capture_name = Base.PCRE.capture_names(m.regex.regex)
-    if !isempty(m.captures)
-        for i = 1:Base.length(m.captures)
-            capture_name = get(idx_to_capture_name, i, i) |> Symbol
-            d[capture_name] = m.captures[i]
-        end
-    end
-    # Dict(Symbol(n)=>m[Symbol(n)] for n in values(Base.PCRE.capture_names(m.regex.regex)))
-    return d
-end
-
-
 
 function text_object_part(cmd::AbstractString)::Union{String,Nothing}
     m = match(REGS.text_object, cmd)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5625f0d3-7886-46f5-8291-8beac120df2f)
![image](https://github.com/user-attachments/assets/92b1472b-423f-4159-aac5-881593ea28c1)
![image](https://github.com/user-attachments/assets/f1655c49-e3b7-4bf1-8ba8-163fb2c3db5c)
The `Dict` interface should have all the necessary methods as the `OrderedDict` and all the relevant tests pass. The ones that do not are the ones that are broken also in other PRs and in the CI of the repo. (As a side note, shouldn't these be marked as `@test_broken` if they are known not to pass? Or at least `@test_broken` in the relevant environments that they do not pass in? That is Ubuntu 1.11 only (and 1.12 which is not yet tested in the CI)? [action](https://github.com/caleb-allen/VimBindings.jl/actions/runs/13135453969/job/36649746570))