### PR TITLE
Switch to insert and fallback on bracketed paste start

### DIFF
--- a/src/VimBindings.jl
+++ b/src/VimBindings.jl
@@ -78,6 +78,11 @@ function strike_key(c, s::LE.MIState)::StrikeKeyResult
     if c == "\e\e"
         empty!(KEY_STACK)
         return VimAction()
+    # begin bracketed paste
+    elseif c == "\e[200~"
+        empty!(KEY_STACK)
+        trigger_insert_mode(s)
+        return Fallback(cs)
     end
     append!(KEY_STACK, c)
 


### PR DESCRIPTION
Thanks for the useful package!

In case a bracketed paste start indicator (https://en.wikipedia.org/wiki/Bracketed-paste) is sent in normal mode, it almost definitely means that the user was trying to paste something.

Currently the bracketed paste start indicator is swallowed and the pasted text is interpreted as commands. At the pasted text will probably switch to insert mode, but the pasting will continue in non-bracketed paste mode.

This PR detects the start of a bracketed paste, enters insert mode and then passes the start bracketed paste indicator as a fallback.