### PR TITLE
Support remapping of keys in `simple_motions`

### DIFF
--- a/src/config.jl
+++ b/src/config.jl
@@ -5,6 +5,7 @@ User configuration of VimBindings.jl behavior
 module Config
 using Preferences
 import ..VimBindings as VB
+import Pkg
 
 
 # idea taken from PreferenceTools.jl
@@ -32,7 +33,10 @@ end
 const prefs = (
     :development_mode => false,
     :system_clipboard => false,
+    # values should be chars, but TOML-based prefs need strings
+    :remap => Dict(),
 )
+
 function pref_set_name(pref::Symbol)
     string(pref) * "!" |> Symbol
 end

--- a/src/motion.jl
+++ b/src/motion.jl
@@ -6,6 +6,7 @@ const LE = LineEdit
 using ..TextUtils
 using ..Util
 using ..Commands
+using ..Config
 
 export Motion, MotionType, simple_motions, complex_motions, partial_complex_motions, insert_motions, gen_motion,
     is_stationary, down, up, word_next, word_big_next, word_end, word_back,
@@ -405,6 +406,7 @@ const insert_motions = Dict{Char,Any}(
         end
     end
 )
+
 const simple_motions = Dict{Char,Function}(
     'h' => left,
     'l' => right,
@@ -429,6 +431,17 @@ const simple_motions = Dict{Char,Function}(
     'L' => nothing
     =#
 )
+
+for (key_str, replacement_str) in Config.remap()
+    key = only(key_str)
+    replacement = only(replacement_str)
+    @debug "Remapping key" key replacement action
+    key in keys(simple_motions) || error("Error in remap configuration: '$key' is not an implemented motion and cannot be replaced")
+    action = simple_motions[key]
+    delete!(simple_motions, key)
+    simple_motions[replacement] = action
+    @debug "Remapped key" key replacement action
+end
 
 const complex_motions = Dict{Regex,Any}(
     r"f(.)" => (buf, char::Union{Char,Int}) -> begin

--- a/src/pkgtools.jl
+++ b/src/pkgtools.jl
@@ -6,7 +6,7 @@ Tools for running or testing the package. This module is meant for code that is
 The end of this file contains precompilation code
 """
 module PkgTools
-import ..VimBuffer, ..parse_command, ..testbuf, ..execute, ..well_formed, ..partial_well_formed
+import ..VimBuffer, ..parse_command, ..testbuf, ..execute, ..well_formed, ..partial_well_formed, ..simple_motions
 import ..Changes: record, undo!, redo!, freeze, thaw!, reset!
 import ..TextUtils: junction_type, TextChar, is_word_start, is_whitespace_start,
     is_object_start, is_word_end, is_object_end, is_whitespace_end
@@ -16,10 +16,15 @@ const TEST_STRING = """abcdefghijklmnopqrstuvwxyz "' 0987654321 A B C D E F G H|
 
 
 function some_vim_commands()::Vector{String}
+    motion_keys = collect(filter(!=('0'), keys(simple_motions)))
+    pop!(motion_keys)
+    simple_commands = join(motion_keys, ' ')
+    simple_commands_with_repeat = join(map(c -> '3' * c, motion_keys), ' ')
+
     s = """
-        h j k l
-        3h 3j 3k 3l
-        w W e E b B ^ \$ 0
+        $simple_commands
+        $simple_commands_with_repeat
+        0
         dh daw cw ciw caW caw daW cW ct"
         fa Fa ta Ta a A i I o O x X C cc dd s S D
         u \x12


### PR DESCRIPTION
Attempt at a solution to #94

Remaining work:
- [ ] Debug remap issues when the new key is more than 1 byte, ie with a unicode key such as `ù` 

This puts the remapping configuration into the existing Config module as a set of methods: `remap!()` for setting keys, and `remap()` for reading the existing remap setting. 

Usage looks like so (after loading VimBindings)

```julia
julia> VimBindings.Config.remap!(Dict(
           "^" => "q",
       ))

julia> VimBindings.Config.remap()
Dict{String, Any} with 1 entry:
  "^" => "q"
```

The REPL session must be restarted in order for the config changes to take effect.

When the package is first loaded, these values are iterated to replace the existing actions. The "replaceable" keys are restricted to those in the map of simple motions: https://github.com/caleb-allen/VimBindings.jl/blob/315d18add65f1770802159e22d320a04f8fb0fcb/src/motion.jl#L408

The PR also contains some changes for the precompilation so that the vim commands used during precompile do not assume specific keys and instead refer to the `simple_motions` dictionary (where the remapping happens)

An issue that arises is that the second entry in the below example. My hunch is that the processing for the simple motions assumes each key is 1 byte, but `ù` is multiple bytes. The answer to this issue may be to process bytes until a full character has been read, or perhaps needs to read a specific control sequence instead of a unicode key? 

This example sets the value, but then VimBindings crashes when it is loaded thereafter.
```julia
julia> VimBindings.Config.remap!(Dict(
           "^" => "q",
           "\$" => "ù"
       ))

julia> VimBindings.Config.remap()
Dict{String, Any} with 2 entries:
  "^"  => "q"
  "\$" => "ù"
```
